### PR TITLE
Build and Publish Docker image to Docker Hub

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1,0 +1,20 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  docker-build-push:
+    uses: sgibson91/.github/.github/workflows/docker-build.yaml@main
+    with:
+      image_name: sgibson91/bump-helm-deps-action
+    secrets:
+      docker_username: ${{ secrets.DOCKER_USERNAME }}
+      docker_password: ${{ secrets.DOCKER_PASSWORD }}

--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://sgibson91/bump-helm-deps-action'
 branding:
   icon: 'check-circle'
   color: 'purple'


### PR DESCRIPTION
Instead of building the docker image every time the action is called, build and push it to Docker Hub in CI and then pull the built image when the action is run.