### PR TITLE
Update Docker CI to only build/push latest tag

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -4,17 +4,26 @@ on:
   push:
     branches:
       - "main"
-    tags:
-      - "v*.*.*"
   pull_request:
     branches:
       - "main"
 
 jobs:
   docker-build-push:
-    uses: sgibson91/.github/.github/workflows/docker-build.yaml@main
-    with:
-      image_name: sgibson91/bump-helm-deps-action
-    secrets:
-      docker_username: ${{ secrets.DOCKER_USERNAME }}
-      docker_password: ${{ secrets.DOCKER_PASSWORD }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2.4.0
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.8.0
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ github.repository }}:latest


### PR DESCRIPTION
There isn't an easy way to pull a specific tag for Docker-based Actions - so just use the latest tag on Docker Hub