### PR TITLE
Fix bug with assigning reviewers

### DIFF
--- a/helm_bot/github_api.py
+++ b/helm_bot/github_api.py
@@ -43,17 +43,20 @@ def assign_reviewers(
             contain an authorisation token.
     """
     logger.info("Assigning reviewers to Pull Request: {}", pr_url)
+    json = {}
 
     if reviewers:
         logger.info("Assigning reviewers: {}", reviewers)
+        json["reviewers"] = reviewers
     if team_reviewers:
         logger.info("Assigning team reviewers: {}", team_reviewers)
+        json["team_reviewers"] = team_reviewers
 
     url = "/".join([pr_url, "requested_reviewers"])
     post_request(
         url,
         headers=header,
-        json={"reviewers": reviewers, "team_reviewers": team_reviewers},
+        json=json,
     )
 
 

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -40,7 +40,7 @@ def test_assign_reviewers():
         mocked_func.assert_called_with(
             "/".join([test_url, "requested_reviewers"]),
             headers=test_header,
-            json={"reviewers": test_reviewers, "team_reviewers": []},
+            json={"reviewers": test_reviewers},
         )
 
 


### PR DESCRIPTION
Assigning reviewers failed if either reviewers or team_reviewers was left blank. This PR fixes that bug.