### PR TITLE
Add a ruamel-based yaml parser to the repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use a Python 3.9 slim image
 FROM python:3.10.4-slim
 
+# Install gcc
+RUN apt-get update && apt-get install --yes gcc
+
 # Create and set the 'app' working directory
 RUN mkdir /app
 WORKDIR /app

--- a/helm_bot/app.py
+++ b/helm_bot/app.py
@@ -4,7 +4,6 @@ import random
 import string
 from itertools import compress, product
 
-import yaml
 from loguru import logger
 
 from .github_api import (
@@ -17,8 +16,10 @@ from .github_api import (
 )
 from .http_requests import get_request
 from .pull_version_info import get_chart_versions
+from .yaml_parser import YamlParser
 
 HERE = os.getcwd()
+yaml = YamlParser()
 
 
 def edit_config(
@@ -42,13 +43,13 @@ def edit_config(
         str: The updated helm chart config
     """
     resp = get_request(download_url, headers=header, output="text")
-    chart_yaml = yaml.safe_load(resp)
+    chart_yaml = yaml.yaml_string_to_object(resp)
 
     for chart, dep in product(charts_to_update, chart_yaml["dependencies"]):
         if dep["name"] == chart:
             dep["version"] = chart_info[chart]
 
-    encoded_chart_yaml = yaml.safe_dump(chart_yaml).encode("utf-8")
+    encoded_chart_yaml = yaml.object_to_yaml_str(chart_yaml).encode("utf-8")
     base64_bytes = base64.b64encode(encoded_chart_yaml)
     chart_yaml = base64_bytes.decode("utf-8")
 

--- a/helm_bot/pull_version_info.py
+++ b/helm_bot/pull_version_info.py
@@ -1,9 +1,9 @@
-import yaml
-
 from .http_requests import get_request
+from .yaml_parser import YamlParser
 
 API_ROOT = "https://api.github.com"
 RAW_ROOT = "https://raw.githubusercontent.com"
+yaml = YamlParser()
 
 
 def pull_from_requirements_file(
@@ -26,7 +26,7 @@ def pull_from_requirements_file(
         output_dict (dict): A dictionary containing the names of the helm chart
             dependencies and their versions.
     """
-    chart_reqs = yaml.safe_load(get_request(api_url, headers=header, output="text"))
+    chart_reqs = yaml.yaml_string_to_object(get_request(api_url, headers=header, output="text"))
 
     for chart in chart_reqs["dependencies"]:
         output_dict[chart_name][chart["name"]] = chart["version"]
@@ -54,7 +54,7 @@ def pull_from_chart_file(
         output_dict (dict): A dictionary containing the names of the helm chart
             dependencies and their versions.
     """
-    chart_reqs = yaml.safe_load(get_request(api_url, headers=header, output="text"))
+    chart_reqs = yaml.yaml_string_to_object(get_request(api_url, headers=header, output="text"))
     output_dict[dependency] = chart_reqs["version"]
 
     return output_dict
@@ -81,7 +81,7 @@ def pull_from_github_pages(
         output_dict (dict): A dictionary containing the names of the helm chart
             dependencies and their versions.
     """
-    chart_reqs = yaml.safe_load(get_request(api_url, headers=header, output="text"))
+    chart_reqs = yaml.yaml_string_to_object(get_request(api_url, headers=header, output="text"))
     updates_sorted = sorted(
         chart_reqs["entries"][dependency], key=lambda k: k["created"]
     )

--- a/helm_bot/pull_version_info.py
+++ b/helm_bot/pull_version_info.py
@@ -26,7 +26,9 @@ def pull_from_requirements_file(
         output_dict (dict): A dictionary containing the names of the helm chart
             dependencies and their versions.
     """
-    chart_reqs = yaml.yaml_string_to_object(get_request(api_url, headers=header, output="text"))
+    chart_reqs = yaml.yaml_string_to_object(
+        get_request(api_url, headers=header, output="text")
+    )
 
     for chart in chart_reqs["dependencies"]:
         output_dict[chart_name][chart["name"]] = chart["version"]
@@ -54,7 +56,9 @@ def pull_from_chart_file(
         output_dict (dict): A dictionary containing the names of the helm chart
             dependencies and their versions.
     """
-    chart_reqs = yaml.yaml_string_to_object(get_request(api_url, headers=header, output="text"))
+    chart_reqs = yaml.yaml_string_to_object(
+        get_request(api_url, headers=header, output="text")
+    )
     output_dict[dependency] = chart_reqs["version"]
 
     return output_dict
@@ -81,7 +85,9 @@ def pull_from_github_pages(
         output_dict (dict): A dictionary containing the names of the helm chart
             dependencies and their versions.
     """
-    chart_reqs = yaml.yaml_string_to_object(get_request(api_url, headers=header, output="text"))
+    chart_reqs = yaml.yaml_string_to_object(
+        get_request(api_url, headers=header, output="text")
+    )
     updates_sorted = sorted(
         chart_reqs["entries"][dependency], key=lambda k: k["created"]
     )

--- a/helm_bot/yaml_parser.py
+++ b/helm_bot/yaml_parser.py
@@ -1,0 +1,34 @@
+from io import StringIO
+
+import ruamel.yaml
+
+
+def represent_none(self, data):
+    return self.represent_scalar("tag:yaml.org,2002:null", "null")
+
+
+class YamlParser:
+    def __init__(self):
+        self.yaml = ruamel.yaml.YAML()
+        self.yaml.indent(mapping=3, sequence=2, offset=0)
+        self.yaml.allow_duplicate_keys = True
+        self.yaml.explicit_start = False
+        self.yaml.representer.add_representer(type(None), represent_none)
+
+    def object_to_yaml_str(self, obj, options={}):
+        string_stream = StringIO()
+        self.yaml.dump(obj, string_stream, **options)
+        output_str = string_stream.getvalue()
+        string_stream.close()
+
+        return output_str
+
+    def yaml_string_to_object(self, string, options={}):
+        return self.yaml.load(string, **options)
+
+    def yaml_file_to_object(self, file_path, options={}):
+        return self.yaml.load(file_path, **options)
+
+    def object_to_yaml_file(self, obj, file_path, options={}):
+        with open(file_path, "w") as fp:
+            self.yaml.dump(obj, fp, **options)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 incremental==21.3.0
 jmespath==1.0.0
 loguru==0.6.0
-pyyaml==6.0
 requests==2.27.1
+ruamel.yaml==0.17.21
 twisted==22.4.0

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,8 +1,7 @@
 import base64
 from unittest.mock import patch
 
-import yaml
-
+from helm_bot.yaml_parser import YamlParser
 from helm_bot.github_api import (
     add_labels,
     assign_reviewers,
@@ -16,6 +15,8 @@ from helm_bot.github_api import (
 
 test_url = "http://jsonplaceholder.typicode.com"
 test_header = {"Authorization": "token ThIs_Is_A_ToKeN"}
+
+yaml = YamlParser()
 
 
 def test_add_labels():
@@ -51,7 +52,7 @@ def test_create_commit():
     test_commit_msg = "This is a commit message"
 
     test_contents = {"key1": "This is a test"}
-    test_contents = yaml.safe_dump(test_contents).encode("utf-8")
+    test_contents = yaml.object_to_yaml_str(test_contents).encode("utf-8")
     test_contents = base64.b64encode(test_contents)
     test_contents = test_contents.decode("utf-8")
 

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,7 +1,6 @@
 import base64
 from unittest.mock import patch
 
-from helm_bot.yaml_parser import YamlParser
 from helm_bot.github_api import (
     add_labels,
     assign_reviewers,
@@ -12,6 +11,7 @@ from helm_bot.github_api import (
     get_contents,
     get_ref,
 )
+from helm_bot.yaml_parser import YamlParser
 
 test_url = "http://jsonplaceholder.typicode.com"
 test_header = {"Authorization": "token ThIs_Is_A_ToKeN"}


### PR DESCRIPTION
Use a ruamel-based YAML parser since it is supported, unlike pyyaml, and supports round-trip editing of YAML. We need a class though because ruamel only writes to a stream, not to objects.