### PR TITLE
Change separator for dependabot branch names

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,8 @@ updates:
       day: "monday"
       time: "00:00"
       timezone: "Europe/London"
+    pull-request-branch-name:
+      separator: "-"
   # Maintain dependencies for pip
   - package-ecosystem: "pip"
     directory: "/"
@@ -19,6 +21,8 @@ updates:
     ignore:
       - update-types: ["version-update:semver-patch"]
         dependency-name: "*"
+    pull-request-branch-name:
+      separator: "-"
   # Maintain dependencies for docker
   - package-ecosystem: "docker"
     directory: "/"
@@ -27,3 +31,5 @@ updates:
       day: "monday"
       time: "00:00"
       timezone: "Europe/London"
+    pull-request-branch-name:
+      separator: "-"

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Test Building Docker Image
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
         uses: docker/build-push-action@v3.0.0
         with:
           push: false
-          tags: ${{ github.repository }}:latest
+          tags: ${{ github.repository }}:${{ github.head_ref }}
 
   docker-build-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This allows us to use `head_ref` as a valid Docker image tag in CI