### PR TITLE
Parse chart_urls object to UpdateHelmDeps class

### DIFF
--- a/helm_bot/main.py
+++ b/helm_bot/main.py
@@ -191,6 +191,7 @@ def main():
         repository,
         github_token,
         chart_path,
+        chart_urls,
         base_branch=base_branch,
         head_branch=head_branch,
         labels=labels,


### PR DESCRIPTION
Fixes a bug that the chart URLs were not being passed to the UpdateHelmDeps class