### PR TITLE
Add the chart name into the head branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Here is a list detailing the assumptions that the Action makes.
 | `github_token` | A GitHub token to make requests to the API with. Requires write permissions to: create new branches, make commits, and open Pull Requests. | :x: | `${{github.token}}` |
 | `repository` | The GitHub repository where the helm chart is stored | :x: | `${{github.repository}}` |
 | `base_branch` | The base branch to open the Pull Request against | :x: | `main` |
-| `head_branch` | The branch to commit to and open a Pull Request from | :x: | `helm_dep_bump-WXYZ` where `WXYZ` will be a randomly generated ascii string (to avoid clashes) |
+| `head_branch` | The branch to commit to and open a Pull Request from | :x: | `bump-helm-deps/{{ chart name }}/WXYZ` where `chart name` is derived from the `chart_path`, and `WXYZ` will be a randomly generated ascii string (to avoid clashes) |
 | `labels` | A comma-separated list of labels to apply to the opened Pull Request. Labels must already exist in the repository. | :x: | `[]` |
 | `reviewers` | A comma-separated list of GitHub users (without the leading `@`) to request reviews from | :x: | `[]` |
 | `team_reviewers` | A comma-separated list of GitHub teams, in the form `ORG_NAME/TEAM_NAME`, to request reviews from | :x: | `[]` |

--- a/helm_bot/github_api.py
+++ b/helm_bot/github_api.py
@@ -168,7 +168,7 @@ class GitHubAPI:
                 "No relevant Pull Requests found. A new Pull Request will be opened."
             )
             random_id = "".join(random.sample(string.ascii_letters, 4))
-            self.inputs.head_branch = "-".join([self.inputs.head_branch, random_id])
+            self.inputs.head_branch = "/".join([self.inputs.head_branch, random_id])
             self.pr_exists = False
         else:
             logger.info(

--- a/helm_bot/main.py
+++ b/helm_bot/main.py
@@ -31,7 +31,6 @@ class UpdateHelmDeps:
         self.chart_path = chart_path
         self.chart_urls = chart_urls
         self.base_branch = base_branch
-        self.head_branch = head_branch
         self.labels = labels
         self.reviewers = reviewers
         self.team_reviewers = team_reviewers
@@ -41,6 +40,8 @@ class UpdateHelmDeps:
             "Accept": "application/vnd.github.v3+json",
             "Authorization": f"token {github_token}",
         }
+        self.chart_name = self.chart_path.split("/")[-2]
+        self.head_branch = "/".join([head_branch, self.chart_name])
 
     def update_versions(self):
         """Update the dependencies of a local helm chart with the latest versions

--- a/helm_bot/pull_version_info.py
+++ b/helm_bot/pull_version_info.py
@@ -96,11 +96,6 @@ class HelmChartVersionPuller:
         """Get the versions of dependent helm charts"""
         logger.info("Fetching current subchart versions from helm chart...")
         self.inputs.chart_yaml, self.inputs.sha = self._get_config(self.branch)
-        self.inputs.chart_name = (
-            self.inputs.chart_yaml["name"]
-            if "name" in self.inputs.chart_yaml.keys()
-            else self.inputs.chart_path.split("/")[-2]
-        )
 
         self.chart_versions = {
             chart["name"]: {"current": chart["version"]}

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -419,7 +419,11 @@ class TestGitHubAPI(unittest.TestCase):
                 output="json",
             )
             self.assertFalse(github.pr_exists)
-            self.assertTrue(helm_deps.head_branch.startswith("bump-helm-deps-"))
+            self.assertTrue(
+                helm_deps.head_branch.startswith(
+                    "/".join(["bump-helm-deps", "chart-name"])
+                )
+            )
 
     def test_find_existing_pull_request_match(self):
         helm_deps = UpdateHelmDeps(
@@ -435,7 +439,7 @@ class TestGitHubAPI(unittest.TestCase):
             return_value=[
                 {
                     "head": {
-                        "label": "bump-helm-deps",
+                        "label": "bump-helm-deps/chart-name",
                     },
                     "number": 1,
                 }
@@ -453,7 +457,9 @@ class TestGitHubAPI(unittest.TestCase):
                 output="json",
             )
             self.assertTrue(github.pr_exists)
-            self.assertEqual(helm_deps.head_branch, "bump-helm-deps")
+            self.assertEqual(
+                helm_deps.head_branch, "/".join(["bump-helm-deps", "chart-name"])
+            )
             self.assertEqual(github.pr_number, 1)
 
     def test_get_ref(self):


### PR DESCRIPTION
If you want to run this action in parallel across multiple local helm charts, all the commits will be tried to push to the same branch. This PR adds the chart name into the head branch name to avoid clashes.