### PR TITLE
Correct docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ Here is a list detailing the assumptions that the Action makes.
 | `chart_urls` | A string-serialised dictionary storing the location of the dependent and their versions. E.g. `'{"binderhub": "https://raw.githubusercontent.com/jupyterhub/helm-chart/gh-pages/index.yaml"}'` | :white_check_mark: | - |
 | `github_token` | A GitHub token to make requests to the API with. Requires write permissions to: create new branches, make commits, and open Pull Requests. | :x: | `${{github.token}}` |
 | `repository` | The GitHub repository where the helm chart is stored | :x: | `${{github.repository}}` |
-| `base_branch` | The base branch to open the Pull Request against | :x: | `main` |
+| `base_branch` | The base branch to open the Pull Request against | :x: | `${{github.ref_name}}` |
 | `head_branch` | The branch to commit to and open a Pull Request from | :x: | `bump-helm-deps/{{ chart name }}/WXYZ` where `chart name` is derived from the `chart_path`, and `WXYZ` will be a randomly generated ascii string (to avoid clashes) |
 | `labels` | A comma-separated list of labels to apply to the opened Pull Request. Labels must already exist in the repository. | :x: | `[]` |
 | `reviewers` | A comma-separated list of GitHub users (without the leading `@`) to request reviews from | :x: | `[]` |
-| `team_reviewers` | A comma-separated list of GitHub teams, in the form `ORG_NAME/TEAM_NAME`, to request reviews from | :x: | `[]` |
+| `team_reviewers` | A comma-separated list of GitHub teams to request reviews from | :x: | `[]` |
 | `dry_run` | Perform a dry-run of the action. A Pull Request will not be opened, but a log message will indicate if any helm chart versions can be bumped. | :x: | `False` |
 
 ## :lock: Permissions

--- a/action.yaml
+++ b/action.yaml
@@ -30,14 +30,14 @@ inputs:
     default: ${{ github.repository }}
   base_branch:
     description: |
-      The base branch to open the Pull Request against. Defaults to "main".
+      The base branch to open the Pull Request against. Defaults to ${{ github.ref_name }}.
     required: false
-    default: "main"
+    default: ${{ github.ref_name }}
   head_branch:
     description: |
       The branch to commit to and open a Pull Request from. Defaults to
-      `helm_dep_bump-WXYZ` where `WXYZ` will be a randomly generated ascii string
-      (to avoid clashes).
+      `bump-helm-deps/{{ chart name }}/WXYZ` where chart name is derived from chart_path
+      and `WXYZ` is a randomly generated ascii string (to avoid clashes).
     required: false
     default: "helm_dep_bump"
   labels:
@@ -52,8 +52,7 @@ inputs:
     required: false
   team_reviewers:
     description: |
-      A comma-separated list of GitHub teams, in the form ORG_NAME/TEAM_NAME, to
-      request reviews from.
+      A comma-separated list of GitHub teams to request reviews from.
     required: false
   dry_run:
     description: |


### PR DESCRIPTION
- Team reviewers should be just "team_name", not "org_name/team_name"
- base_branch now defaults to github.ref_name