### PR TITLE
Set default for base_branch back to main

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -30,9 +30,9 @@ inputs:
     default: ${{ github.repository }}
   base_branch:
     description: |
-      The base branch to open the Pull Request against. Defaults to ${{ github.ref_name }}.
+      The base branch to open the Pull Request against. Defaults to "main".
     required: false
-    default: ${{ github.ref_name }}
+    default: "main"
   head_branch:
     description: |
       The branch to commit to and open a Pull Request from. Defaults to


### PR DESCRIPTION
Fix the issue that the action does not load correctly when triggered by a schedule https://github.com/alan-turing-institute/hub23-deploy/runs/6791297518?check_suite_focus=true