### PR TITLE
Explicitly check dry_run str is "false" to convert to bool

### DIFF
--- a/helm_bot/main.py
+++ b/helm_bot/main.py
@@ -164,7 +164,7 @@ def main():
     # Check the dry_run variable is properly set
     if isinstance(dry_run, str) and (dry_run == "true"):
         dry_run = True
-    elif isinstance(dry_run, str) and (dry_run != "true"):
+    elif isinstance(dry_run, str) and (dry_run == "false"):
         dry_run = False
     elif isinstance(dry_run, bool) and not dry_run:
         pass


### PR DESCRIPTION
When converting the `dry_run` variable to a boolean from a string, it must now have the value `"false"` in order to be converted to `False`. This will ensure that the exception is properly executed and that a PR will be opened for any value of `dry_run` that is not `"true"`